### PR TITLE
Fix `HierarchicalMachine` signature to conform with base method

### DIFF
--- a/tests/test_nesting.py
+++ b/tests/test_nesting.py
@@ -29,6 +29,10 @@ except ImportError:  # pragma: no cover
 state_separator = State.separator
 
 
+class Dummy(object):
+    pass
+
+
 class TestTransitions(TestsCore):
 
     def setUp(self):
@@ -40,6 +44,10 @@ class TestTransitions(TestsCore):
     def tearDown(self):
         State.separator = state_separator
         pass
+
+    def test_add_model(self):
+        model = Dummy()
+        self.stuff.machine.add_model(model, initial='E')
 
     def test_function_wrapper(self):
         from transitions.extensions.nesting import FunctionWrapper

--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -200,8 +200,8 @@ class HierarchicalMachine(Machine):
         self._buffered_transitions = []
         _super(HierarchicalMachine, self).__init__(*args, **kwargs)
 
-    def add_model(self, model):
-        _super(HierarchicalMachine, self).add_model(model)
+    def add_model(self, model, initial=None):
+        _super(HierarchicalMachine, self).add_model(model, initial=initial)
         models = listify(model)
         for m in models:
             m = self if m == 'self' else m


### PR DESCRIPTION
# Problem:

Base method `add_model` accepts `initial` keyword argument. But HierarchicalMachine does not. 

# Solution
I modified method signature to accept parameter.
Added test